### PR TITLE
Add initial home experience with live sports sections

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,4 @@
+NEXT_PUBLIC_SUPABASE_URL=http://localhost:54321
+NEXT_PUBLIC_SUPABASE_ANON_KEY=dev-anon-key
+ANON_SALT=dev-only-salt
+NEXT_PUBLIC_SITE_TZ=America/New_York

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.next
+node_modules
+dist
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Sportle Cards
+
+Daily sports trivia built with Next.js, TypeScript, Tailwind CSS, and Supabase.
+
+## Getting Started
+
+Install dependencies:
+
+```bash
+npm i
+```
+
+Run the development server:
+
+```bash
+npm run dev
+```

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,16 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  experimental: {
+    typedRoutes: true
+  },
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'placehold.co'
+      }
+    ]
+  }
+};
+
+export default nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "sports-trivia",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@supabase/auth-helpers-nextjs": "^0.10.0",
+    "@supabase/supabase-js": "^2.43.0",
+    "next": "14.2.3",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "20.12.7",
+    "@types/react": "18.3.3",
+    "@types/react-dom": "18.3.0",
+    "autoprefixer": "10.4.19",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.3",
+    "postcss": "8.4.38",
+    "tailwindcss": "3.4.3",
+    "typescript": "5.4.5"
+  }
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -1,0 +1,79 @@
+import Header from '@/components/Header';
+import LiveScoresTicker from '@/components/LiveScoresTicker';
+import OnThisDay from '@/components/OnThisDay';
+import PlayCta from '@/components/PlayCta';
+import FeaturedCard from '@/components/FeaturedCard';
+import Footer from '@/components/Footer';
+import { formatET, nowInET } from '@/lib/time';
+import Link from 'next/link';
+
+export default function HomePage() {
+  const today = formatET(nowInET(), {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric'
+  });
+
+  return (
+    <div className="flex min-h-screen flex-col bg-slate-50">
+      <Header />
+      <LiveScoresTicker />
+      <main className="flex-1">
+        <section className="mx-auto w-full max-w-6xl px-4 py-16 md:px-6">
+          <div className="grid gap-10 md:grid-cols-12 md:items-center">
+            <div className="space-y-6 md:col-span-7">
+              <p className="text-sm font-semibold uppercase tracking-widest text-emerald-600">{today}</p>
+              <h1 className="text-4xl font-bold tracking-tight text-slate-900 sm:text-5xl">
+                Daily sports trivia, live scores, and history that plays to win.
+              </h1>
+              <p className="max-w-2xl text-lg text-slate-600">
+                Answer the public question every morning, then log in to unlock the member challenge, track your streak, and climb
+                the Sportle leaderboard. Trivia. Cards. Prizes coming soon.
+              </p>
+              <PlayCta />
+              <div className="flex items-center justify-center gap-3 text-sm text-slate-600 md:justify-start">
+                <span className="font-medium">Want the merch?</span>
+                <Link
+                  href="/shop"
+                  className="inline-flex items-center gap-2 font-semibold text-emerald-600 hover:text-emerald-700"
+                  aria-label="Visit the Sportle Cards shop"
+                >
+                  Visit the shop
+                  <span aria-hidden>→</span>
+                </Link>
+              </div>
+            </div>
+            <div className="md:col-span-5">
+              <div className="rounded-3xl border border-emerald-100 bg-white p-6 shadow-xl">
+                <h2 className="text-lg font-semibold text-slate-900">Why play Sportle Cards?</h2>
+                <ul className="mt-4 space-y-3 text-sm text-slate-600">
+                  <li className="flex items-start gap-3">
+                    <span className="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-emerald-500 text-xs font-semibold text-white">
+                      1
+                    </span>
+                    Fresh sports trivia daily at midnight Eastern.
+                  </li>
+                  <li className="flex items-start gap-3">
+                    <span className="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-emerald-500 text-xs font-semibold text-white">
+                      2
+                    </span>
+                    Track your streaks with Supabase-authenticated profiles.
+                  </li>
+                  <li className="flex items-start gap-3">
+                    <span className="mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full bg-emerald-500 text-xs font-semibold text-white">
+                      3
+                    </span>
+                    Shop limited-run cards celebrating iconic sports moments.
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </section>
+        <OnThisDay />
+        <FeaturedCard />
+      </main>
+      <Footer />
+    </div>
+  );
+}

--- a/src/app/api/home/live-scores/route.ts
+++ b/src/app/api/home/live-scores/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server';
+import { mockScores } from '@/lib/mocks';
+
+export const runtime = 'edge';
+export const revalidate = 90;
+
+const CACHE_CONTROL = 's-maxage=90, stale-while-revalidate=60';
+
+export async function GET() {
+  try {
+    // TODO: Replace mock with real live score provider integration.
+    const data = mockScores;
+
+    return NextResponse.json(
+      { ok: true, data },
+      {
+        status: 200,
+        headers: {
+          'Cache-Control': CACHE_CONTROL
+        }
+      }
+    );
+  } catch (error) {
+    console.error('live-scores error', error);
+    return NextResponse.json(
+      { ok: false, error: 'Failed to load live scores' },
+      {
+        status: 500,
+        headers: {
+          'Cache-Control': CACHE_CONTROL
+        }
+      }
+    );
+  }
+}

--- a/src/app/api/home/otd/route.ts
+++ b/src/app/api/home/otd/route.ts
@@ -1,0 +1,35 @@
+import { NextResponse } from 'next/server';
+import { mockOtd } from '@/lib/mocks';
+
+export const runtime = 'edge';
+export const revalidate = 21600;
+
+const CACHE_CONTROL = 's-maxage=21600, stale-while-revalidate=3600';
+
+export async function GET() {
+  try {
+    // TODO: Replace mock with Wikimedia or cached source.
+    const data = mockOtd;
+
+    return NextResponse.json(
+      { ok: true, data },
+      {
+        status: 200,
+        headers: {
+          'Cache-Control': CACHE_CONTROL
+        }
+      }
+    );
+  } catch (error) {
+    console.error('otd error', error);
+    return NextResponse.json(
+      { ok: false, error: 'Failed to load history' },
+      {
+        status: 500,
+        headers: {
+          'Cache-Control': CACHE_CONTROL
+        }
+      }
+    );
+  }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from 'next';
+import { Inter } from 'next/font/google';
+import '@/styles/globals.css';
+
+const inter = Inter({ subsets: ['latin'] });
+
+export const metadata: Metadata = {
+  title: 'Sportle Cards',
+  description: 'Daily sports trivia with live scores and historical context.'
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <html lang="en">
+      <body className={`${inter.className} bg-white text-slate-900`}>{children}</body>
+    </html>
+  );
+}

--- a/src/components/AuthButtons.tsx
+++ b/src/components/AuthButtons.tsx
@@ -1,0 +1,104 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import type { User } from '@supabase/supabase-js';
+import { createSupabaseBrowserClient } from '@/lib/supabaseClient';
+
+export default function AuthButtons() {
+  const supabase = useMemo(() => createSupabaseBrowserClient(), []);
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let mounted = true;
+
+    supabase.auth
+      .getUser()
+      .then(({ data }) => {
+        if (mounted) {
+          setUser(data.user ?? null);
+          setLoading(false);
+        }
+      })
+      .catch((error) => {
+        console.error('Failed to get user', error);
+        if (mounted) {
+          setLoading(false);
+        }
+      });
+
+    const {
+      data: { subscription }
+    } = supabase.auth.onAuthStateChange((_event, session) => {
+      setUser(session?.user ?? null);
+    });
+
+    return () => {
+      mounted = false;
+      subscription.unsubscribe();
+    };
+  }, [supabase]);
+
+  const handleLogin = () => {
+    console.info('TODO: open Supabase Auth login modal');
+  };
+
+  const handleRegister = () => {
+    console.info('TODO: open Supabase Auth register modal');
+  };
+
+  const handleSignOut = async () => {
+    try {
+      await supabase.auth.signOut();
+    } catch (error) {
+      console.error('Failed to sign out', error);
+    }
+  };
+
+  if (loading) {
+    return <div className="h-10 w-24 animate-pulse rounded-full bg-slate-200" aria-hidden />;
+  }
+
+  if (!user) {
+    return (
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          onClick={handleLogin}
+          className="rounded-full border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-100"
+        >
+          Login
+        </button>
+        <button
+          type="button"
+          onClick={handleRegister}
+          className="rounded-full bg-slate-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-slate-800"
+        >
+          Register
+        </button>
+      </div>
+    );
+  }
+
+  const displayInitial =
+    (user.user_metadata?.full_name as string | undefined)?.[0]?.toUpperCase() ||
+    (user.email?.[0]?.toUpperCase() ?? 'U');
+
+  return (
+    <div className="flex items-center gap-3">
+      <span
+        className="flex h-10 w-10 items-center justify-center rounded-full bg-slate-900 text-sm font-semibold text-white"
+        aria-label={`Signed in as ${user.email ?? 'player'}`}
+      >
+        {displayInitial}
+      </span>
+      <button
+        type="button"
+        onClick={handleSignOut}
+        className="rounded-full border border-slate-300 px-4 py-2 text-sm font-medium text-slate-700 transition hover:bg-slate-100"
+      >
+        Sign out
+      </button>
+    </div>
+  );
+}

--- a/src/components/FeaturedCard.tsx
+++ b/src/components/FeaturedCard.tsx
@@ -1,0 +1,37 @@
+import Image from 'next/image';
+import Link from 'next/link';
+
+export default function FeaturedCard() {
+  return (
+    <section className="mx-auto w-full max-w-6xl px-4 py-12 md:px-6">
+      <div className="grid gap-6 rounded-3xl border border-slate-200 bg-white p-6 shadow-lg md:grid-cols-[2fr,3fr] md:p-10">
+        <div className="relative h-48 overflow-hidden rounded-2xl bg-slate-100 md:h-full">
+          <Image
+            src="https://placehold.co/600x400?text=Sportle+Card"
+            alt="Featured card placeholder"
+            fill
+            className="object-cover"
+            priority
+            sizes="(min-width: 768px) 40vw, 100vw"
+          />
+        </div>
+        <div className="flex flex-col justify-between gap-4">
+          <div>
+            <h3 className="text-xl font-semibold text-slate-900">Featured Card of the Day</h3>
+            <p className="mt-2 text-sm text-slate-600">
+              Collect the limited-run Sportle card that celebrates today&apos;s sports history. New drops every day.
+            </p>
+          </div>
+          <div>
+            <Link
+              href="/shop"
+              className="inline-flex items-center justify-center rounded-full bg-slate-900 px-6 py-3 text-sm font-semibold text-white transition hover:bg-slate-800"
+            >
+              View in Shop
+            </Link>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,28 @@
+import Link from 'next/link';
+
+const footerLinks = [
+  { href: '/about', label: 'About' },
+  { href: '/rules', label: 'Rules' },
+  { href: '/faq', label: 'FAQ' },
+  { href: '/contact', label: 'Contact' },
+  { href: '/privacy', label: 'Privacy' },
+  { href: '/terms', label: 'Terms' }
+];
+
+export default function Footer() {
+  return (
+    <footer className="border-t border-slate-200 bg-slate-50 py-10">
+      <div className="mx-auto flex max-w-6xl flex-col items-center gap-6 px-4 text-sm text-slate-600 md:flex-row md:justify-between md:px-6">
+        <p className="font-semibold text-slate-800">Sportle Cards</p>
+        <nav className="flex flex-wrap justify-center gap-4" aria-label="Footer">
+          {footerLinks.map((link) => (
+            <Link key={link.href} href={link.href} className="hover:text-slate-900">
+              {link.label}
+            </Link>
+          ))}
+        </nav>
+        <p className="text-xs text-slate-500">© {new Date().getFullYear()} Sportle Cards. All rights reserved.</p>
+      </div>
+    </footer>
+  );
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,0 +1,25 @@
+import Link from 'next/link';
+import AuthButtons from './AuthButtons';
+
+export default function Header() {
+  return (
+    <header className="border-b border-slate-200 bg-white">
+      <div className="mx-auto flex max-w-6xl items-center justify-between gap-6 px-4 py-4 md:px-6">
+        <Link href="/" className="text-xl font-semibold tracking-tight text-slate-900">
+          Sportle Cards
+        </Link>
+        <nav className="hidden items-center gap-6 text-sm font-medium text-slate-700 md:flex">
+          <Link href="/" className="transition hover:text-slate-900">
+            Home
+          </Link>
+          <Link href="/shop" className="transition hover:text-slate-900">
+            Shop
+          </Link>
+        </nav>
+        <div className="ml-auto">
+          <AuthButtons />
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/components/LiveScoresTicker.tsx
+++ b/src/components/LiveScoresTicker.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { getJSON } from '@/lib/fetcher';
+import type { LiveScore } from '@/lib/mocks';
+
+interface LiveScoresResponse {
+  ok: boolean;
+  data?: LiveScore[];
+  error?: string;
+}
+
+export default function LiveScoresTicker() {
+  const [scores, setScores] = useState<LiveScore[]>([]);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let active = true;
+
+    getJSON<LiveScoresResponse>('/api/home/live-scores')
+      .then((response) => {
+        if (!active) return;
+        if (response.ok && response.data) {
+          setScores(response.data);
+        } else {
+          setError(response.error ?? 'Unable to load live scores');
+        }
+      })
+      .catch(() => {
+        if (!active) return;
+        setError('Unable to load live scores');
+      });
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
+  const items = scores.length > 0 ? scores : [];
+  const marqueeItems = items.length > 0 ? [...items, ...items] : [];
+
+  return (
+    <section className="bg-slate-900 text-white" aria-label="Live sports scores ticker">
+      <div className="mx-auto flex max-w-6xl items-center gap-4 px-4 py-3 md:px-6">
+        <span className="text-sm font-semibold uppercase tracking-widest text-slate-200">Live Scores</span>
+        <div className="relative flex-1 overflow-hidden">
+          {error ? (
+            <p className="text-sm text-slate-200">{error}</p>
+          ) : items.length === 0 ? (
+            <p className="text-sm text-slate-200">Updating scores…</p>
+          ) : (
+            <div className="flex min-w-full gap-8 whitespace-nowrap" aria-live="polite">
+              <div className="flex min-w-max items-center gap-8 motion-safe:animate-marquee">
+                {marqueeItems.map((score, index) => (
+                  <div key={`${score.league}-${score.home}-${score.away}-${index}`} className="flex items-center gap-2 text-sm">
+                    <span className="font-semibold text-slate-100">[{score.league}]</span>
+                    <span className="text-slate-200">
+                      {score.away}{' '}
+                      <span className="font-semibold">{score.awayScore}</span>
+                      {' – '}
+                      {score.home}{' '}
+                      <span className="font-semibold">{score.homeScore}</span>
+                    </span>
+                    <span className="text-xs text-slate-300">{score.status}</span>
+                    {score.minuteOrInning ? (
+                      <span className="text-xs text-slate-400">{score.minuteOrInning}</span>
+                    ) : null}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/OnThisDay.tsx
+++ b/src/components/OnThisDay.tsx
@@ -1,0 +1,69 @@
+import { getJSON } from '@/lib/fetcher';
+import type { OnThisDayItem } from '@/lib/mocks';
+import { formatET, nowInET } from '@/lib/time';
+
+interface OnThisDayResponse {
+  ok: boolean;
+  data?: OnThisDayItem[];
+  error?: string;
+}
+
+export default async function OnThisDay() {
+  let entries: OnThisDayItem[] = [];
+  let error: string | null = null;
+
+  try {
+    const response = await getJSON<OnThisDayResponse>('/api/home/otd');
+    if (response.ok && response.data) {
+      entries = response.data;
+    } else {
+      error = response.error ?? 'Unable to load history';
+    }
+  } catch (err) {
+    console.error(err);
+    error = 'Unable to load history';
+  }
+
+  const todayLabel = formatET(nowInET(), {
+    month: 'long',
+    day: 'numeric'
+  });
+
+  return (
+    <section className="mx-auto w-full max-w-6xl px-4 py-12 md:px-6" aria-labelledby="on-this-day">
+      <div className="flex flex-col gap-6 md:flex-row md:items-start md:justify-between">
+        <div>
+          <h2 id="on-this-day" className="text-2xl font-semibold text-slate-900">
+            On This Day in Sports
+          </h2>
+          <p className="text-sm text-slate-500">{todayLabel} in sports history</p>
+        </div>
+      </div>
+      {error ? (
+        <p className="mt-4 text-sm text-slate-500">{error}</p>
+      ) : entries.length === 0 ? (
+        <p className="mt-4 text-sm text-slate-500">No historical moments available right now. Check back soon.</p>
+      ) : (
+        <ol className="mt-6 space-y-4" aria-live="polite">
+          {entries.map((item) => (
+            <li key={`${item.year}-${item.text}`} className="rounded-lg border border-slate-200 p-4 shadow-sm">
+              <div className="flex flex-col gap-2 md:flex-row md:items-baseline md:gap-4">
+                <span className="rounded-full bg-slate-900 px-3 py-1 text-sm font-semibold text-white">
+                  {item.year}
+                </span>
+                <p className="text-slate-700">
+                  {item.text}{' '}
+                  {item.url ? (
+                    <a href={item.url} target="_blank" rel="noreferrer" className="font-medium text-blue-600 underline">
+                      Read more
+                    </a>
+                  ) : null}
+                </p>
+              </div>
+            </li>
+          ))}
+        </ol>
+      )}
+    </section>
+  );
+}

--- a/src/components/PlayCta.tsx
+++ b/src/components/PlayCta.tsx
@@ -1,0 +1,15 @@
+import Link from 'next/link';
+
+export default function PlayCta() {
+  return (
+    <div className="flex flex-col items-center gap-4 text-center">
+      <Link
+        href="/play"
+        className="inline-flex items-center justify-center rounded-full bg-emerald-500 px-10 py-4 text-lg font-semibold text-white shadow-lg transition hover:bg-emerald-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-600"
+      >
+        Play Today&apos;s Question (Public)
+      </Link>
+      <p className="text-sm text-slate-600">Log in to play the member question &amp; track your streak.</p>
+    </div>
+  );
+}

--- a/src/lib/fetcher.ts
+++ b/src/lib/fetcher.ts
@@ -1,0 +1,25 @@
+const REVALIDATE_MAP: Record<string, number> = {
+  '/api/home/live-scores': 90,
+  '/api/home/otd': 21600
+};
+
+export async function getJSON<T>(path: string): Promise<T> {
+  if (typeof window === 'undefined') {
+    const revalidate = REVALIDATE_MAP[path] ?? 60;
+    const res = await fetch(path, {
+      next: {
+        revalidate
+      }
+    });
+    if (!res.ok) {
+      throw new Error(`Failed to fetch ${path}: ${res.status}`);
+    }
+    return res.json() as Promise<T>;
+  }
+
+  const res = await fetch(path);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch ${path}: ${res.status}`);
+  }
+  return res.json() as Promise<T>;
+}

--- a/src/lib/mocks.ts
+++ b/src/lib/mocks.ts
@@ -1,0 +1,89 @@
+export type LiveScore = {
+  league: string;
+  home: string;
+  away: string;
+  status: string;
+  minuteOrInning?: string;
+  homeScore: number;
+  awayScore: number;
+};
+
+export type OnThisDayItem = {
+  year: number;
+  text: string;
+  url?: string;
+};
+
+export const mockScores: LiveScore[] = [
+  {
+    league: 'NBA',
+    home: 'Knicks',
+    away: 'Celtics',
+    status: 'Final',
+    homeScore: 112,
+    awayScore: 108
+  },
+  {
+    league: 'MLB',
+    home: 'Yankees',
+    away: 'Red Sox',
+    status: 'Top 7th',
+    minuteOrInning: '7th',
+    homeScore: 4,
+    awayScore: 3
+  },
+  {
+    league: 'NHL',
+    home: 'Rangers',
+    away: 'Devils',
+    status: '2nd Period',
+    minuteOrInning: '12:34',
+    homeScore: 2,
+    awayScore: 2
+  },
+  {
+    league: 'MLS',
+    home: 'NYCFC',
+    away: 'Inter Miami',
+    status: 'HT',
+    minuteOrInning: '45+2',
+    homeScore: 1,
+    awayScore: 1
+  },
+  {
+    league: 'NFL',
+    home: 'Giants',
+    away: 'Eagles',
+    status: 'Sun 1:00 PM',
+    homeScore: 0,
+    awayScore: 0
+  }
+];
+
+export const mockOtd: OnThisDayItem[] = [
+  {
+    year: 1995,
+    text: 'Michael Jordan drops 55 points on the Knicks at Madison Square Garden in just his fifth game back from retirement.',
+    url: 'https://www.nba.com/'
+  },
+  {
+    year: 2004,
+    text: 'Red Sox complete a historic comeback against the Yankees in the ALCS to reach the World Series.',
+    url: 'https://www.mlb.com/'
+  },
+  {
+    year: 1980,
+    text: 'The U.S. hockey team defeats Finland to secure the Olympic gold medal in Lake Placid.',
+    url: 'https://www.olympic.org/'
+  },
+  {
+    year: 2010,
+    text: 'Drew Brees leads the New Orleans Saints to their first Super Bowl victory.',
+    url: 'https://www.nfl.com/'
+  },
+  {
+    year: 1973,
+    text: 'Secretariat wins the Triple Crown with a dominant Belmont Stakes performance.',
+    url: 'https://www.belmontstakes.com/'
+  }
+];

--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,0 +1,34 @@
+import { createClientComponentClient, createServerClient } from '@supabase/auth-helpers-nextjs';
+import type { CookieOptions } from '@supabase/auth-helpers-nextjs';
+import { cookies, type RequestCookies } from 'next/headers';
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+function assertEnv() {
+  if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+    throw new Error('Supabase environment variables are not set');
+  }
+}
+
+export function createSupabaseBrowserClient() {
+  assertEnv();
+  return createClientComponentClient();
+}
+
+export function createSupabaseServerClient(cookieStore: RequestCookies = cookies()) {
+  assertEnv();
+  return createServerClient(SUPABASE_URL!, SUPABASE_ANON_KEY!, {
+    cookies: {
+      get(name: string) {
+        return cookieStore.get(name)?.value;
+      },
+      set(name: string, value: string, options?: CookieOptions) {
+        cookieStore.set({ name, value, ...options });
+      },
+      remove(name: string, options?: CookieOptions) {
+        cookieStore.set({ name, value: '', maxAge: 0, ...options });
+      }
+    }
+  });
+}

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -1,0 +1,41 @@
+const SITE_TZ = process.env.NEXT_PUBLIC_SITE_TZ ?? 'America/New_York';
+
+export function nowInET(): Date {
+  const now = new Date();
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    timeZone: SITE_TZ,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+    hour12: false,
+    timeZoneName: 'shortOffset'
+  });
+
+  const parts = formatter.formatToParts(now);
+  const lookup = Object.fromEntries(parts.map((part) => [part.type, part.value]));
+  const offsetRaw = lookup.timeZoneName ?? 'GMT-05:00';
+  const offsetMatch = offsetRaw.match(/GMT([+-]\d{1,2})(?::?(\d{2}))?/i);
+  const offsetHours = offsetMatch ? Number(offsetMatch[1]) : -5;
+  const offsetMinutes = offsetMatch && offsetMatch[2] ? Number(offsetMatch[2]) : 0;
+  const sign = offsetHours >= 0 ? '+' : '-';
+  const paddedHours = String(Math.abs(offsetHours)).padStart(2, '0');
+  const paddedMinutes = String(Math.abs(offsetMinutes)).padStart(2, '0');
+
+  const isoString = `${lookup.year}-${lookup.month}-${lookup.day}T${lookup.hour}:${lookup.minute}:${lookup.second}${sign}${paddedHours}:${paddedMinutes}`;
+  return new Date(isoString);
+}
+
+export function formatET(input: string | number | Date, options?: Intl.DateTimeFormatOptions): string {
+  const date = typeof input === 'string' || typeof input === 'number' ? new Date(input) : input;
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    timeZone: SITE_TZ,
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+    ...options
+  });
+  return formatter.format(date);
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,0 +1,15 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light;
+}
+
+body {
+  @apply bg-white text-slate-900 antialiased;
+}
+
+a {
+  @apply text-blue-600 hover:text-blue-700 underline-offset-4;
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,0 +1,27 @@
+import type { Config } from 'tailwindcss';
+
+const config: Config = {
+  content: [
+    './src/app/**/*.{ts,tsx}',
+    './src/components/**/*.{ts,tsx}',
+    './src/lib/**/*.{ts,tsx}',
+    './src/styles/**/*.{ts,tsx}',
+    './src/**/*.{ts,tsx}'
+  ],
+  theme: {
+    extend: {
+      keyframes: {
+        marquee: {
+          '0%': { transform: 'translateX(0%)' },
+          '100%': { transform: 'translateX(-50%)' }
+        }
+      },
+      animation: {
+        marquee: 'marquee 20s linear infinite'
+      }
+    }
+  },
+  plugins: []
+};
+
+export default config;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/components/*": ["./src/components/*"],
+      "@/lib/*": ["./src/lib/*"],
+      "@/styles/*": ["./src/styles/*"],
+      "@/app/*": ["./src/app/*"]
+    },
+    "types": ["@types/node"]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- scaffold the Sportle Cards home layout with hero, play CTA, live scores ticker, on-this-day history, and featured shop card
- add edge API routes for mocked live scores and history with ISR caching plus shared mocks, fetcher, time, and Supabase client helpers
- implement Supabase-auth aware header buttons and base Tailwind styling, configuration, and project scaffolding

## Testing
- npm install *(fails: registry returns 403 Forbidden for required packages)*

------
https://chatgpt.com/codex/tasks/task_e_68c9a69384cc8325991098ddd25a05dd