### PR TITLE
refactor: separate supabase server client

### DIFF
--- a/src/lib/supabaseClient.ts
+++ b/src/lib/supabaseClient.ts
@@ -1,6 +1,4 @@
-import { createClientComponentClient, createServerClient } from '@supabase/auth-helpers-nextjs';
-import type { CookieOptions } from '@supabase/auth-helpers-nextjs';
-import { cookies, type RequestCookies } from 'next/headers';
+import { createClientComponentClient } from '@supabase/auth-helpers-nextjs';
 
 const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
@@ -14,21 +12,4 @@ function assertEnv() {
 export function createSupabaseBrowserClient() {
   assertEnv();
   return createClientComponentClient();
-}
-
-export function createSupabaseServerClient(cookieStore: RequestCookies = cookies()) {
-  assertEnv();
-  return createServerClient(SUPABASE_URL!, SUPABASE_ANON_KEY!, {
-    cookies: {
-      get(name: string) {
-        return cookieStore.get(name)?.value;
-      },
-      set(name: string, value: string, options?: CookieOptions) {
-        cookieStore.set({ name, value, ...options });
-      },
-      remove(name: string, options?: CookieOptions) {
-        cookieStore.set({ name, value: '', maxAge: 0, ...options });
-      }
-    }
-  });
 }

--- a/src/lib/supabaseServerClient.ts
+++ b/src/lib/supabaseServerClient.ts
@@ -1,0 +1,28 @@
+import { createServerClient, type CookieOptions } from '@supabase/auth-helpers-nextjs';
+import { cookies, type RequestCookies } from 'next/headers';
+
+const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+function assertEnv() {
+  if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+    throw new Error('Supabase environment variables are not set');
+  }
+}
+
+export function createSupabaseServerClient(cookieStore: RequestCookies = cookies()) {
+  assertEnv();
+  return createServerClient(SUPABASE_URL!, SUPABASE_ANON_KEY!, {
+    cookies: {
+      get(name: string) {
+        return cookieStore.get(name)?.value;
+      },
+      set(name: string, value: string, options?: CookieOptions) {
+        cookieStore.set({ name, value, ...options });
+      },
+      remove(name: string, options?: CookieOptions) {
+        cookieStore.set({ name, value: '', maxAge: 0, ...options });
+      }
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- add a server-specific Supabase helper that wires cookies from next/headers
- limit the existing Supabase client helper to the browser client export

## Testing
- npm run dev *(fails to fetch Next.js version info in this environment but server becomes ready)*

------
https://chatgpt.com/codex/tasks/task_e_68c9acf5032083259b4a2a3914bd2ed2