### PR TITLE
Fix server-side fetcher base URL handling

### DIFF
--- a/src/lib/fetcher.ts
+++ b/src/lib/fetcher.ts
@@ -6,7 +6,9 @@ const REVALIDATE_MAP: Record<string, number> = {
 export async function getJSON<T>(path: string): Promise<T> {
   if (typeof window === 'undefined') {
     const revalidate = REVALIDATE_MAP[path] ?? 60;
-    const res = await fetch(path, {
+    const baseUrl = process.env.NEXT_PUBLIC_BASE_URL ?? 'http://localhost:3000';
+    const requestUrl = /^https?:\/\//i.test(path) ? path : new URL(path, baseUrl).toString();
+    const res = await fetch(requestUrl, {
       next: {
         revalidate
       }


### PR DESCRIPTION
## Summary
- resolve server-side getJSON requests against NEXT_PUBLIC_BASE_URL (or localhost fallback) so fetch receives an absolute URL
- leave browser fetching behavior unchanged to keep relative /api calls intact
- smoke test the home page to confirm On This Day data now renders

## Testing
- npm run dev


------
https://chatgpt.com/codex/tasks/task_e_68c9ae0232888325a5e8854c27932913