### PR TITLE
Fix duplicated entries in tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,6 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["DOM", "DOM.Iterable", "ESNext"],
-
     "lib": [
       "DOM",
       "DOM.Iterable",
@@ -32,35 +30,4 @@
   },
   "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]
-      "@/components/*": [
-        "./src/components/*"
-      ],
-      "@/lib/*": [
-        "./src/lib/*"
-      ],
-      "@/styles/*": [
-        "./src/styles/*"
-      ],
-      "@/app/*": [
-        "./src/app/*"
-      ]
-    },
-    "types": [
-      "@types/node"
-    ],
-    "plugins": [
-      {
-        "name": "next"
-      }
-    ]
-  },
-  "include": [
-    "next-env.d.ts",
-    "**/*.ts",
-    "**/*.tsx",
-    ".next/types/**/*.ts"
-  ],
-  "exclude": [
-    "node_modules"
-  ]
 }


### PR DESCRIPTION
## Summary
- remove duplicated compilerOptions, include, and exclude entries from the TypeScript configuration
- keep a single lib entry to maintain valid JSON structure

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c9b6bcf49c8325b11e4b39fced4bd5